### PR TITLE
Expand environment interface documentation

### DIFF
--- a/DrillInterface/src/DrillInterface.jl
+++ b/DrillInterface/src/DrillInterface.jl
@@ -168,6 +168,13 @@ function number_of_envs end
 # ------------------------------------------------------------
 # Environment wrappers
 # ------------------------------------------------------------
+"""
+    AbstractEnvWrapper{E <: AbstractEnv} <: AbstractEnv
+
+Wraps a single `AbstractEnv` `E` (transform observations, actions, rewards, or metadata).
+Subtypes remain `AbstractEnv`; implement the same methods as the inner env, plus `unwrap` to expose `E`.
+Compare `AbstractParallelEnvWrapper`.
+"""
 abstract type AbstractEnvWrapper{E <: AbstractEnv} <: AbstractEnv end
 
 """
@@ -207,6 +214,15 @@ Unwrap one layer of environment wrapper to access the underlying environment.
 """
 function unwrap end
 
+"""
+    unwrap_all(env) -> AbstractEnv
+
+Repeatedly call [`unwrap`](@ref) while [`is_wrapper`](@ref) remains true, returning the innermost non-wrapper environment.
+
+The argument must be a wrapper that implements `unwrap` on the first iteration. Packages may add methods (for example to return a vector of sub-environments from a parallel runner).
+
+See also [`unwrap`](@ref).
+"""
 function unwrap_all(env::AbstractEnv)
     wrapped = true
     while wrapped

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,7 +5,11 @@
 ```@docs
 AbstractEnv
 AbstractParallelEnv
+AbstractEnvWrapper
 AbstractParallelEnvWrapper
+is_wrapper
+unwrap
+unwrap_all
 reset!
 act!
 observe
@@ -68,6 +72,7 @@ ReplayBuffer
 ```@docs
 MultiThreadedParallelEnv
 BroadcastedParallelEnv
+MultiAgentParallelEnv
 NormalizeWrapperEnv
 ScalingWrapperEnv
 MonitorWrapperEnv

--- a/docs/src/guide/environments.md
+++ b/docs/src/guide/environments.md
@@ -2,50 +2,180 @@
 
 ## Dependencies for environment implementers
 
-Packages or code that only implement environments should depend on **DrillInterface**, not Drill. DrillInterface is lightweight (minimal dependencies) and provides the types and function signatures needed to implement `AbstractEnv`. Add **Drill** when you need training (PPO, SAC), parallel environment wrappers (`MultiThreadedParallelEnv`, `BroadcastedParallelEnv`), or other wrappers (e.g. `NormalizeWrapperEnv`). Environment validation (`check_env`) is provided by DrillInterface; Drill re-exports it for convenience. DrillInterface is available from the same repository as Drill.
+Packages or code that only implement environments should depend on **DrillInterface**, not Drill. DrillInterface is lightweight (minimal dependencies) and provides the types and function signatures needed to implement [`AbstractEnv`](@ref). Add **Drill** when you need training (PPO, SAC), built-in parallel runners ([`BroadcastedParallelEnv`](@ref), [`MultiThreadedParallelEnv`](@ref)), or training-oriented wrappers (for example [`NormalizeWrapperEnv`](@ref), [`MonitorWrapperEnv`](@ref)). Environment validation (`check_env`) is provided by DrillInterface; Drill re-exports it for convenience. DrillInterface ships from the same repository as Drill.
 
-## Interface
+---
 
-Implement `AbstractEnv` with these required methods:
+## Types: how the pieces fit together
+
+Drill splits **single-step** environments from **vectorized (parallel)** ones, and splits **wrappers** the same way.
+
+```mermaid
+flowchart TB
+    subgraph envs [Environment kinds]
+        AE["AbstractEnv\n(single env)"]
+        APE["AbstractParallelEnv\n(N copies, one step API)"]
+        AE --> APE
+    end
+    subgraph wrap [Wrappers]
+        AEW["AbstractEnvWrapper{E<:AbstractEnv}\nwraps one env"]
+        APEW["AbstractParallelEnvWrapper{E<:AbstractParallelEnv}\nwraps parallel env"]
+        AEW --> AE
+        APEW --> APE
+    end
+```
+
+| Type | What it represents | Typical examples |
+|------|--------------------|------------------|
+| [`AbstractEnv`](@ref) | One Markov decision process instance | `CartPoleEnv`, your physics sim |
+| [`AbstractParallelEnv`](@ref) | Several **independent** env instances stepped together; training sees a batch | [`BroadcastedParallelEnv`](@ref), [`MultiThreadedParallelEnv`](@ref), [`MultiAgentParallelEnv`](@ref) |
+| [`AbstractEnvWrapper`](@ref) | Decorates **one** [`AbstractEnv`](@ref); still a single env to callers | [`ScalingWrapperEnv`](@ref) (in Drill) |
+| [`AbstractParallelEnvWrapper`](@ref) | Decorates **one** [`AbstractParallelEnv`](@ref); still parallel to callers | [`NormalizeWrapperEnv`](@ref), [`MonitorWrapperEnv`](@ref) |
+
+Important details:
+
+- **`AbstractParallelEnv <: AbstractEnv` in Julia**, so a parallel env is an `AbstractEnv` in the type system. Algorithms and utilities still **dispatch on `AbstractParallelEnv`** when they need batched observations, batched flags, and the parallel `act!` return tuple—so implement the **parallel contracts** below when you subtype `AbstractParallelEnv`.
+- **`is_wrapper`** ([`is_wrapper`](@ref)): for a value typed as `AbstractParallelEnv`, only [`AbstractParallelEnvWrapper`](@ref) counts as a wrapper. A plain [`AbstractParallelEnv`](@ref) is not a wrapper even though it contains sub-envs.
+- **`unwrap` / `unwrap_all`**: define `unwrap` on your wrapper type to return the inner environment. `unwrap_all` peels repeated wrapper layers until [`is_wrapper`](@ref) is false; call it only on chains that start with a wrapper. On [`BroadcastedParallelEnv`](@ref), `unwrap_all` returns the `Vector` of underlying [`AbstractEnv`](@ref) instances (Drill extends the DrillInterface fallback).
+
+---
+
+## Single environment: [`AbstractEnv`](@ref)
+
+Implement a concrete subtype of [`AbstractEnv`](@ref) and the methods below. This is the only type most domain packages need to define; Drill’s parallel runners wrap **vectors of** these envs.
+
+### Single-env methods
+
+| Method | Contract |
+|--------|----------|
+| [`reset!(env)`](@ref) | Puts the env in an initial state. Implementations in Drill typically return `nothing`; callers use [`observe(env)`](@ref) after reset. |
+| [`act!(env, action)`](@ref) | Applies **one** action for that instance. Returns the **scalar reward** (same numeric type you use elsewhere, often `Float32`). |
+| [`observe(env)`](@ref) | Current observation; must match [`observation_space(env)`](@ref) (shape and element type). |
+| [`terminated(env)`](@ref), [`truncated(env)`](@ref) | Each returns `Bool`. |
+| [`action_space(env)`](@ref), [`observation_space(env)`](@ref) | [`AbstractSpace`](@ref) values ([`Box`](@ref), [`Discrete`](@ref), …). |
+| [`get_info(env)`](@ref) | Returns a **single** `Dict` (may be empty). |
+
+Episode boundaries are **not** auto-handled for a single env: after `terminated` or `truncated` is true, the **trainer or evaluation code** calls [`reset!`](@ref) before the next episode.
+
+### Minimal skeleton
 
 ```julia
 struct MyEnv <: AbstractEnv
-    # state fields
+    # ...
 end
 
-DrillInterface.reset!(env::MyEnv)           # Reset to initial state
-DrillInterface.act!(env::MyEnv, action)     # Take action, return reward
-DrillInterface.observe(env::MyEnv)          # Return current observation
-DrillInterface.terminated(env::MyEnv)       # Terminal state reached?
-DrillInterface.truncated(env::MyEnv)        # Time limit reached?
-DrillInterface.action_space(env::MyEnv)     # Return action space
-DrillInterface.observation_space(env::MyEnv) # Return observation space
+DrillInterface.reset!(env::MyEnv) = ...
+DrillInterface.act!(env::MyEnv, action) = ...  # returns reward
+DrillInterface.observe(env::MyEnv) = ...
+DrillInterface.terminated(env::MyEnv) = ...
+DrillInterface.truncated(env::MyEnv) = ...
+DrillInterface.action_space(env::MyEnv) = ...
+DrillInterface.observation_space(env::MyEnv) = ...
+DrillInterface.get_info(env::MyEnv) = Dict{String, Any}()
 ```
+
+Optional but recommended: store an `rng` field and support `Random.seed!(env, seed)` (DrillInterface provides a default that seeds `env.rng` when that field exists).
+
+---
+
+## Parallel environment: [`AbstractParallelEnv`](@ref)
+
+A parallel env owns **`N`** single-env instances and exposes **one** stepped interface to training code. PPO-style collection in Drill calls [`observe`](@ref), then [`act!`](@ref) with **one action per sub-env**, then [`observe`](@ref) again.
+
+### When you implement `AbstractParallelEnv` yourself
+
+Most users **do not** subtype [`AbstractParallelEnv`](@ref) directly. They implement [`AbstractEnv`](@ref) once and build:
+
+```julia
+env = BroadcastedParallelEnv([MyEnv() for _ in 1:N])
+# or
+env = MultiThreadedParallelEnv([MyEnv() for _ in 1:N])
+```
+
+Implement a **custom** [`AbstractParallelEnv`](@ref) only if you need different batching, remote workers, or a process model that these structs do not cover. Then you must match the **same contracts** as [`BroadcastedParallelEnv`](@ref) / [`MultiThreadedParallelEnv`](@ref) so algorithms and `check_env` stay consistent.
+
+### Parallel batch methods
+
+| Method | Parallel contract |
+|--------|-------------------|
+| [`number_of_envs(env)`](@ref) | **Required.** Returns `N`. |
+| [`reset!(env)`](@ref) | Resets **all** sub-instances (often returns `nothing`). |
+| [`observe(env)`](@ref) | Returns **one observation per sub-env**: either a `Vector` of length `N` (each element one obs) or a batched array whose last dimension is `N`, consistent with how policies in your pipeline read it. Built-in runners return `Vector` of observations. |
+| [`terminated(env)`](@ref), [`truncated(env)`](@ref) | Each returns `AbstractVector{Bool}` of length `N`. |
+| [`get_info(env)`](@ref) | Returns **per-env** info: `Vector` of `Dict` of length `N` (same stacking style as [`observe`](@ref) for composite types). |
+| [`action_space`](@ref), [`observation_space`](@ref) | Same space as **each** sub-env (homogeneous spaces). If your struct stores sub-envs in an `envs` field, DrillInterface fallbacks can forward from `envs[1]`; otherwise define these explicitly. |
+| [`act!(env, actions)`](@ref) | `actions` has **one entry per sub-env** (`length(actions) == number_of_envs(env)`). Returns a **tuple** `(rewards, terminateds, truncateds, infos)` where each is a vector of length `N`. |
+
+### Auto-reset and truncation
+
+Built-in parallel envs **auto-reset** a sub-env as soon as it is [`terminated`](@ref) or [`truncated`](@ref) after a step, so the batch always reflects post-reset state on the next [`observe`](@ref). For **truncation**, the info dict for that index should include `"terminal_observation"` with the last pre-reset observation; Drill uses this for value bootstrapping (see trajectory collection).
+
+### Seeding
+
+`Random.seed!(env::AbstractParallelEnv, seed)` in DrillInterface seeds `env.envs[i]` with `seed + i - 1`. If your custom parallel type does not use an `envs` field, override `Random.seed!` yourself.
+
+### [`MultiAgentParallelEnv`](@ref)
+
+[`MultiAgentParallelEnv`](@ref) is still an [`AbstractParallelEnv`](@ref): it flattens several parallel batches into **one** logical vector of length `total_envs` (possibly different group sizes). Use it when you intentionally combine multiple [`AbstractParallelEnv`](@ref) backends behind one interface.
+
+---
+
+## Wrappers: [`AbstractEnvWrapper`](@ref) vs [`AbstractParallelEnvWrapper`](@ref)
+
+| Wrapper base | Wraps | Subtypes | Example in Drill |
+|--------------|-------|----------|------------------|
+| [`AbstractEnvWrapper{E<:AbstractEnv}`](@ref) | One [`AbstractEnv`](@ref) | Still [`AbstractEnv`](@ref), **not** [`AbstractParallelEnv`](@ref) | [`ScalingWrapperEnv`](@ref) |
+| [`AbstractParallelEnvWrapper{E<:AbstractParallelEnv}`](@ref) | One [`AbstractParallelEnv`](@ref) | Still [`AbstractParallelEnv`](@ref) | [`NormalizeWrapperEnv`](@ref), [`MonitorWrapperEnv`](@ref) |
+
+**Composition rules:**
+
+- **Normalize / monitor training:** wrap the **parallel** env: `NormalizeWrapperEnv(BroadcastedParallelEnv([...]))`.
+- **Scale observations and actions for a policy:** wrap each **single** env, then parallelize: `BroadcastedParallelEnv([ScalingWrapperEnv(MyEnv()) for _ in 1:N])`. Putting [`ScalingWrapperEnv`](@ref) outside the parallel runner would not match the single-env API Drill expects for that wrapper.
+- Implement **`unwrap(wrapper) = wrapper.env`** (or the field holding the inner env) so `unwrap_all` and logging utilities can reach the inside.
+
+Further wrapper-specific options are in the [Environment Wrappers](./wrappers.md) guide page.
+
+---
 
 ## Spaces
 
 ```julia
 # Continuous actions/observations
-Box{Float32}(low, high)  # low/high are vectors
+Box{Float32}(low, high)  # low/high are arrays; shapes must match
 
 # Discrete actions
 Discrete(n)              # Actions: 1, 2, ..., n
-Discrete(n, start=0)     # Actions: 0, 1, ..., n-1
+Discrete(n, start = 0) # Actions: 0, 1, ..., n-1
 ```
 
-## Parallel Environments
+---
+
+## Built-in parallel runners (recommended)
 
 ```julia
-# Multi-threaded (multi-threaded, keep threading overhead in mind!)
-env = MultiThreadedParallelEnv([MyEnv() for _ in 1:n_envs])
-
-# Broadcasted (single-threaded, often fastest for cheap environments like those in ClassicControlEnvironments.jl)
+# Single-threaded broadcast (often best for cheap envs)
 env = BroadcastedParallelEnv([MyEnv() for _ in 1:n_envs])
+
+# Multi-threaded stepping (when work per step is large enough to amortize threading)
+env = MultiThreadedParallelEnv([MyEnv() for _ in 1:n_envs])
 ```
 
-## Environment Validation
+Both require **the same concrete env type** and **isequal** observation and action spaces across copies.
+
+---
+
+## Environment validation
 
 ```julia
-check_env(env)  # Validates interface implementation
+check_env(env)  # Single AbstractEnv or AbstractParallelEnv
 ```
 
+`check_env` exercises required methods and space consistency. Run it on a **single** [`AbstractEnv`](@ref) and on your full [`AbstractParallelEnv`](@ref) stack after wiring parallelization and wrappers.
+
+---
+
+## See also
+
+- [Environment Wrappers](./wrappers.md) — normalize, scale, monitor APIs
+- [Algorithms](./algorithms.md) — what each algorithm expects for `env`
+- [API Reference](../api.md) — full docstrings for [`AbstractEnv`](@ref), [`AbstractParallelEnv`](@ref), and related methods

--- a/src/environment_wrappers/multiAgentParallelEnv.jl
+++ b/src/environment_wrappers/multiAgentParallelEnv.jl
@@ -1,3 +1,8 @@
+"""
+    MultiAgentParallelEnv(envs::Vector{<:AbstractParallelEnv})
+
+Combine several [`AbstractParallelEnv`](@ref) instances that share the same observation and action spaces into one logical parallel env. [`number_of_envs`](@ref) is the sum of sub-counts; [`observe`](@ref), flags, and infos are flattened in sub-env order. Actions are routed to each sub-parallel-env chunk in parallel.
+"""
 struct MultiAgentParallelEnv{E <: AbstractParallelEnv} <: AbstractParallelEnv
     envs::Vector{E}
     env_counts::Vector{Int}  # Number of sub-envs in each parallel env


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Environments guide now explains how `AbstractEnv`, `AbstractParallelEnv`, `AbstractEnvWrapper`, and `AbstractParallelEnvWrapper` relate, what each API returns for single vs parallel stepping, when to implement a custom parallel env vs wrapping copies with `BroadcastedParallelEnv` / `MultiThreadedParallelEnv`, auto-reset and `terminal_observation`, composition (e.g. scaling per worker vs normalize on the parallel stack), and `unwrap` / `unwrap_all` / `is_wrapper`.

## Supporting changes

- **DrillInterface:** docstrings for `AbstractEnvWrapper` and `unwrap_all`.
- **Drill:** docstring for `MultiAgentParallelEnv`.
- **API reference:** `@docs` entries for `AbstractEnvWrapper`, `is_wrapper`, `unwrap`, `unwrap_all`, and `MultiAgentParallelEnv`.

## Verification

`makedocs` (Documenter + Vitepress) was run locally from `docs/` with the updated `environments.md`; the site build completed without dead-link failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0e897a7-1e92-4906-a559-c4e75f194408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0e897a7-1e92-4906-a559-c4e75f194408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

