### PR TITLE
Improve output logging

### DIFF
--- a/src/Drill.jl
+++ b/src/Drill.jl
@@ -68,6 +68,8 @@ export Agent
 include("buffers/buffers.jl")
 export OffPolicyTrajectory, ReplayBuffer, RolloutBuffer, Trajectory
 
+include("logging/training_progress.jl")
+
 include("algorithms/traits.jl")
 
 include("algorithms/sac.jl")
@@ -102,7 +104,8 @@ export collect_trajectory
 # New logging interface and no-op logger; concrete backends provided via package extensions
 include("logging/logging_utils.jl")
 include("logging/no_training_logger.jl")
-export NoTrainingLogger, get_hparams
+export NoTrainingLogger, get_hparams, TrainingProgressOptions, make_training_progress_meter,
+    plain_progress_options, progress_next!
 
 import DrillInterface: check_env
 

--- a/src/algorithms/ppo.jl
+++ b/src/algorithms/ppo.jl
@@ -216,6 +216,7 @@ Rollouts use `alg.n_steps` steps per sub-environment per iteration. Training sto
 # Keyword arguments
 - `ad_type`: Lux AD backend for `compute_gradients` (default `AutoZygote()`).
 - `callbacks`: Optional vector of [`AbstractCallback`](@ref) hooks; see [`on_training_start`](@ref), [`on_rollout_start`](@ref), etc.
+- `progress_options`: [`TrainingProgressOptions`](@ref) for the progress bar (colors, output stream). Use [`plain_progress_options`](@ref) for file logging.
 
 Returns `nothing` (mutates `agent` in place). On early exit from callbacks, returns `nothing` without completing the full schedule.
 """
@@ -225,7 +226,8 @@ function train!(
         alg::PPO{T}, #TODO remove alg from here, use agent.alg instead
         max_steps::Int;
         ad_type::Lux.Training.AbstractADType = AutoZygote(),
-        callbacks::Union{Vector{<:AbstractCallback}, Nothing} = nothing
+        callbacks::Union{Vector{<:AbstractCallback}, Nothing} = nothing,
+        progress_options::TrainingProgressOptions = TrainingProgressOptions(),
     ) where {T}
     to = TimerOutput()
     setup_section = begin_timed_section!(to, "setup")
@@ -245,10 +247,7 @@ function train!(
     agent.verbose > 0 && @info "Training with total_steps: $total_steps,
     iterations: $iterations, n_steps: $n_steps, n_envs: $n_envs"
 
-    progress_meter = Progress(
-        total_steps, desc = "Training...",
-        showspeed = true, enabled = agent.verbose > 0
-    )
+    progress_meter = make_training_progress_meter(total_steps, agent.verbose, progress_options)
 
     train_state = agent.train_state
 
@@ -390,8 +389,8 @@ function train!(
         push!(total_losses, mean(losses))
         push!(total_grad_norms, mean(grad_norms))
         if agent.verbose > 1
-            ProgressMeter.next!(
-                progress_meter;
+            progress_next!(
+                progress_meter, progress_options;
                 step = n_steps * n_envs,
                 showvalues = [
                     ("explained_variance", explained_variance),
@@ -404,10 +403,10 @@ function train!(
                     ("fps", total_fps[i]),
                     ("grad_norm", total_grad_norms[i]),
                     ("learning_rate", learning_rate),
-                ]
+                ],
             )
         elseif agent.verbose > 0
-            ProgressMeter.next!(progress_meter, step = n_steps * n_envs)
+            progress_next!(progress_meter, progress_options, step = n_steps * n_envs)
         end
 
         log_scalar!(agent.logger, "train/entropy_loss", total_entropy_losses[i])

--- a/src/algorithms/sac.jl
+++ b/src/algorithms/sac.jl
@@ -504,6 +504,7 @@ The five-argument form reuses an existing `replay_buffer` (same observation/acti
 # Keyword arguments
 - `callbacks`: Optional vector of [`AbstractCallback`](@ref) hooks.
 - `ad_type`: Lux AD backend for gradient computation (default `AutoZygote()`).
+- `progress_options`: [`TrainingProgressOptions`](@ref) for the progress bar (colors, output stream). Use [`plain_progress_options`](@ref) for file logging.
 
 Returns `(agent, replay_buffer, training_stats)`.
 """
@@ -515,7 +516,8 @@ function train!(
         max_steps::Int;
         #TODO: remove union?
         callbacks::Union{Vector{<:AbstractCallback}, Nothing} = nothing,
-        ad_type::Lux.Training.AbstractADType = AutoZygote()
+        ad_type::Lux.Training.AbstractADType = AutoZygote(),
+        progress_options::TrainingProgressOptions = TrainingProgressOptions(),
     )
     to = TimerOutput()
     n_envs = number_of_envs(env)
@@ -545,10 +547,7 @@ function train!(
 
     total_steps = n_steps * n_envs + alg.train_freq * n_envs * (iterations - 1)
 
-    progress_meter = Progress(
-        total_steps, desc = "Training...",
-        showspeed = true, enabled = agent.verbose > 0
-    )
+    progress_meter = make_training_progress_meter(total_steps, agent.verbose, progress_options)
 
     agent.verbose > 0 && @info "Starting SAC training with buffer size: $(length(replay_buffer)),
     start_steps: $(alg.start_steps), train_freq: $(alg.train_freq), number_of_envs: $(n_envs),

--- a/src/logging/training_progress.jl
+++ b/src/logging/training_progress.jl
@@ -1,0 +1,66 @@
+"""
+    TrainingProgressOptions
+
+Configuration for [`ProgressMeter`](https://github.com/timholy/ProgressMeter.jl) during training.
+
+# Fields
+- `output::IO = stderr`: Stream for progress output. Redirect to a tty path when running under a cluster scheduler.
+- `color::Symbol = :green`: Progress bar color. Use `:normal` for plain text without ANSI escape codes.
+- `valuecolor::Symbol = :blue`: Color for metric values when `verbose > 1`.
+- `showspeed::Bool = true`: Show average time per iteration.
+
+Use [`plain_progress_options`](@ref) for file-friendly output on HPC clusters.
+"""
+Base.@kwdef struct TrainingProgressOptions
+    output::IO = stderr
+    color::Symbol = :green
+    valuecolor::Symbol = :blue
+    showspeed::Bool = true
+end
+
+"""
+    plain_progress_options(; output = stderr, showspeed = true) -> TrainingProgressOptions
+
+Return progress options without ANSI colors, suitable for logging to file.
+"""
+function plain_progress_options(; output::IO = stderr, showspeed::Bool = true)
+    return TrainingProgressOptions(;
+        output = output,
+        color = :normal,
+        valuecolor = :normal,
+        showspeed = showspeed,
+    )
+end
+
+"""
+    make_training_progress_meter(total_steps, verbose, options = TrainingProgressOptions()) -> Progress
+
+Create a training progress meter from total steps, agent verbosity, and options.
+"""
+function make_training_progress_meter(
+        total_steps::Integer,
+        verbose::Integer,
+        options::TrainingProgressOptions = TrainingProgressOptions(),
+    )
+    return Progress(
+        total_steps;
+        desc = "Training...",
+        showspeed = options.showspeed,
+        enabled = verbose > 0,
+        output = options.output,
+        color = options.color,
+    )
+end
+
+"""
+    progress_next!(progress_meter, options::TrainingProgressOptions; kwargs...) -> Nothing
+
+Update a training progress meter, applying configured colors to metric values.
+"""
+function progress_next!(
+        progress_meter::Progress,
+        options::TrainingProgressOptions;
+        kwargs...
+    )
+    return ProgressMeter.next!(progress_meter; valuecolor = options.valuecolor, kwargs...)
+end

--- a/test/test_logging.jl
+++ b/test/test_logging.jl
@@ -44,6 +44,40 @@ end
     end
 end
 
+@testset "Training progress options" begin
+    @testset "plain_progress_options disables colors" begin
+        opts = plain_progress_options()
+        @test opts.color == :normal
+        @test opts.valuecolor == :normal
+        @test opts.output === stderr
+    end
+
+    @testset "make_training_progress_meter respects options" begin
+        io = IOBuffer()
+        opts = plain_progress_options(output = io)
+        meter = make_training_progress_meter(10, 1, opts)
+        @test meter.enabled
+        @test meter.output === io
+        @test meter.color == :normal
+        @test meter.showspeed
+    end
+
+    @testset "make_training_progress_meter disabled when verbose is 0" begin
+        meter = make_training_progress_meter(10, 0)
+        @test !meter.enabled
+    end
+
+    @testset "progress_next! avoids ANSI color codes" begin
+        io = IOBuffer()
+        opts = plain_progress_options(output = io)
+        meter = make_training_progress_meter(4, 2, opts)
+        progress_next!(meter, opts, step = 2, showvalues = [("loss", 0.5)])
+        output = String(take!(io))
+        @test occursin("Training", output)
+        @test !occursin(r"\e\[[0-9;]*m", output)
+    end
+end
+
 @testset "DearDiary logger converts and logs without error" begin
     using DearDiary
     mktempdir() do dir


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds configurable training progress output for PPO and SAC, addressing #71.

- Introduces `TrainingProgressOptions` to control ProgressMeter `output`, `color`, `valuecolor`, and `showspeed`.
- Adds `plain_progress_options()` for file-friendly logging without ANSI color codes (useful on HPC clusters).
- Adds `make_training_progress_meter` and `progress_next!` helpers used by both training loops.
- Exposes `progress_options` keyword to `train!` for PPO and SAC.

## Usage

```julia
using Drill

# Plain text progress for log files
train!(agent, env, alg, max_steps; progress_options = plain_progress_options())

# Redirect progress to a specific tty (e.g. from `tty` in another terminal)
io = open("/dev/pts/3", "w")
train!(agent, env, alg, max_steps; progress_options = TrainingProgressOptions(output = io))
```

## Testing

- Added unit tests in `test/test_logging.jl` for progress option helpers.
- Verified new tests pass locally via direct Julia invocation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb9782ee-2560-4af8-a4af-dff9bd4d1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb9782ee-2560-4af8-a4af-dff9bd4d1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

