### PR TITLE
Make AD benchmarks compatible with TrainState bundle API

### DIFF
--- a/benchmark/bench_utils.jl
+++ b/benchmark/bench_utils.jl
@@ -1,8 +1,10 @@
 module BenchUtils
 
 using Drill
+using Drill.Lux
 using ClassicControlEnvironments
 using Random
+using Statistics: mean
 
 const DEFAULT_SEED = 42
 const DEFAULT_N_ENVS = 2
@@ -124,6 +126,21 @@ function setup_threaded_envs(; n_envs::Int = DEFAULT_N_ENVS)
     return threaded_env, actions
 end
 
+# AirspeedVelocity loads this script via `--bench-on=main`, so helpers must work for both
+# the legacy `agent.train_state::Lux.Training.TrainState` API and the algorithm TrainState bundles.
+function uses_algorithm_train_state(agent)
+    return isdefined(Drill, :AbstractAlgorithmTrainState) &&
+        (agent.train_state isa Drill.AbstractAlgorithmTrainState)
+end
+
+function ppo_lux_train_state(agent)
+    ts = agent.train_state
+    if isdefined(Drill, :lux_train_state)
+        return Drill.lux_train_state(ts)
+    end
+    return ts
+end
+
 function setup_ppo_gradient_data_discrete(; n_envs::Int = DEFAULT_N_ENVS)
     env = make_cartpole_env(; n_envs = n_envs)
     agent, alg = make_ppo_agent(env)
@@ -158,7 +175,7 @@ function setup_ppo_gradient_data_discrete(; n_envs::Int = DEFAULT_N_ENVS)
         break
     end
     @assert batch_data !== nothing
-    train_state = deepcopy(agent.train_state)
+    train_state = deepcopy(ppo_lux_train_state(agent))
     return alg, batch_data, train_state
 end
 
@@ -196,7 +213,7 @@ function setup_ppo_gradient_data_continuous(; n_envs::Int = DEFAULT_N_ENVS)
         break
     end
     @assert batch_data !== nothing
-    train_state = deepcopy(agent.train_state)
+    train_state = deepcopy(ppo_lux_train_state(agent))
     return alg, batch_data, train_state
 end
 
@@ -218,17 +235,170 @@ function setup_sac_gradient_data(; n_envs::Int = DEFAULT_N_ENVS, n_steps::Int = 
         break
     end
     @assert batch_data !== nothing
-    train_state = deepcopy(agent.train_state)
-    ent_train_state = deepcopy(agent.aux.ent_train_state)
-    return (
-        agent.layer,
+    if uses_algorithm_train_state(agent)
+        return (;
+            api = :bundle,
+            layer = agent.layer,
+            alg = alg,
+            batch_data = batch_data,
+            ts = deepcopy(agent.train_state),
+            rng = agent.rng,
+        )
+    end
+    return (;
+        api = :legacy,
+        layer = agent.layer,
+        alg = alg,
+        batch_data = batch_data,
+        train_state = deepcopy(agent.train_state),
+        ent_train_state = deepcopy(agent.aux.ent_train_state),
+        target_ps = agent.aux.Q_target_parameters,
+        target_st = agent.aux.Q_target_states,
+        rng = agent.rng,
+    )
+end
+
+function bench_sac_ad!(ad_backend, state)
+    if state.api === :bundle
+        return _bench_sac_ad_bundle!(ad_backend, state)
+    end
+    return _bench_sac_ad_legacy!(ad_backend, state)
+end
+
+function _bench_sac_ad_bundle!(ad_backend, state)
+    layer = state.layer
+    alg = state.alg
+    batch_data = state.batch_data
+    ts = state.ts
+    rng = state.rng
+    if alg.ent_coef isa AutoEntropyCoefficient
+        target_entropy = Drill.get_target_entropy(alg.ent_coef, action_space(layer))
+        _, log_probs_pi, _ = Drill.action_log_prob(
+            layer,
+            batch_data.observations,
+            Drill.parameters(ts),
+            Drill.states(ts);
+            rng = rng,
+        )
+        c = mean(log_probs_pi .+ target_entropy)
+        ent_data = (; c)
+        _, _, _, ent_ts = Lux.Training.compute_gradients(
+            ad_backend,
+            Drill.SACEntropyObjective(),
+            ent_data,
+            ts.ent_ts,
+        )
+        ts.ent_ts = ent_ts
+    end
+    target_q_values = Drill.compute_target_q_values(
         alg,
-        batch_data,
+        layer,
+        Drill.parameters(ts),
+        Drill.states(ts),
+        (
+            rewards = batch_data.rewards,
+            next_observations = batch_data.next_observations,
+            terminated = batch_data.terminated,
+            log_ent_coef = Drill.entropy_parameters(ts),
+            target_ps = ts.target_parameters,
+            target_st = ts.target_states,
+        );
+        rng = rng,
+    )
+    critic_data = (
+        observations = batch_data.observations,
+        actions = batch_data.actions,
+        target_q_values = target_q_values,
+        actor_ps = ts.actor_ts.parameters,
+        actor_st = ts.actor_ts.states,
+    )
+    critic_objective = Drill.SACCriticObjective(alg, rng)
+    _, _, _, critic_ts = Lux.Training.compute_gradients(
+        ad_backend,
+        critic_objective,
+        critic_data,
+        ts.critic_ts,
+    )
+    ts.critic_ts = critic_ts
+    ent_coef = Float32(Drill.entropy_coefficient(ts))
+    actor_objective = Drill.SACActorObjective(alg, rng)
+    return Lux.Training.compute_gradients(
+        ad_backend,
+        actor_objective,
+        (
+            observations = batch_data.observations,
+            ent_coef = ent_coef,
+            critic_ps = ts.critic_ts.parameters,
+            critic_st = ts.critic_ts.states,
+        ),
+        ts.actor_ts,
+    )
+end
+
+function _bench_sac_ad_legacy!(ad_backend, state)
+    layer = state.layer
+    alg = state.alg
+    batch_data = state.batch_data
+    train_state = state.train_state
+    ent_train_state = state.ent_train_state
+    target_ps = state.target_ps
+    target_st = state.target_st
+    rng = state.rng
+    if alg.ent_coef isa AutoEntropyCoefficient
+        target_entropy = Drill.get_target_entropy(alg.ent_coef, action_space(layer))
+        _, log_probs_pi, _ = Drill.action_log_prob(
+            layer,
+            batch_data.observations,
+            train_state.parameters,
+            train_state.states;
+            rng = rng,
+        )
+        c = mean(log_probs_pi .+ target_entropy)
+        ent_data = (; c)
+        _, _, _, ent_train_state = Lux.Training.compute_gradients(
+            ad_backend,
+            Drill.SACEntropyObjective(),
+            ent_data,
+            ent_train_state,
+        )
+    end
+    target_q_values = Drill.compute_target_q_values(
+        alg,
+        layer,
+        train_state.parameters,
+        train_state.states,
+        (
+            rewards = batch_data.rewards,
+            next_observations = batch_data.next_observations,
+            terminated = batch_data.terminated,
+            log_ent_coef = ent_train_state.parameters,
+            target_ps = target_ps,
+            target_st = target_st,
+        );
+        rng = rng,
+    )
+    critic_data = (
+        observations = batch_data.observations,
+        actions = batch_data.actions,
+        target_q_values = target_q_values,
+    )
+    critic_objective = Drill.SACCriticObjective(alg, rng)
+    _, _, _, train_state = Lux.Training.compute_gradients(
+        ad_backend,
+        critic_objective,
+        critic_data,
         train_state,
-        ent_train_state,
-        agent.aux.Q_target_parameters,
-        agent.aux.Q_target_states,
-        agent.rng,
+    )
+    ent_coef = Float32(exp(first(ent_train_state.parameters.log_ent_coef)))
+    actor_objective = Drill.SACActorObjective(alg, rng)
+    return Lux.Training.compute_gradients(
+        ad_backend,
+        actor_objective,
+        (
+            observations = batch_data.observations,
+            ent_coef = ent_coef,
+        ),
+        train_state,
     )
 end
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -158,67 +158,11 @@ if ENABLE_AD_BACKEND_BENCHES
     end
 
     for (name, ad_backend) in ad_backend_types[[1, 3]] #dont use enzyme without runtime activity
+        # Body lives in BenchUtils so `--bench-on=main` can compare legacy and TrainState-bundle APIs.
         ad_backends["sac"][name] = @benchmarkable begin
-            if alg.ent_coef isa AutoEntropyCoefficient
-                target_entropy = Drill.get_target_entropy(alg.ent_coef, action_space(layer))
-                # Compute c outside autodiff (following current SAC implementation)
-                _, log_probs_pi, _ = Drill.action_log_prob(
-                    layer,
-                    batch_data.observations,
-                    train_state.parameters,
-                    train_state.states;
-                    rng = rng,
-                )
-                c = mean(log_probs_pi .+ target_entropy)
-                ent_data = (; c)
-                _, _, _, ent_train_state = Lux.Training.compute_gradients(
-                    $ad_backend,
-                    Drill.SACEntropyObjective(),
-                    ent_data,
-                    ent_train_state,
-                )
-            end
-            target_q_values = Drill.compute_target_q_values(
-                alg,
-                layer,
-                train_state.parameters,
-                train_state.states,
-                (
-                    rewards = batch_data.rewards,
-                    next_observations = batch_data.next_observations,
-                    terminated = batch_data.terminated,
-                    log_ent_coef = ent_train_state.parameters,
-                    target_ps = target_ps,
-                    target_st = target_st,
-                );
-                rng = rng,
-            )
-            critic_data = (
-                observations = batch_data.observations,
-                actions = batch_data.actions,
-                target_q_values = target_q_values,
-            )
-            critic_objective = Drill.SACCriticObjective(alg, rng)
-            _, _, _, train_state = Lux.Training.compute_gradients(
-                $ad_backend,
-                critic_objective,
-                critic_data,
-                train_state,
-            )
-            ent_coef = Float32(exp(first(ent_train_state.parameters.log_ent_coef)))
-            actor_objective = Drill.SACActorObjective(alg, rng)
-            Lux.Training.compute_gradients(
-                $ad_backend,
-                actor_objective,
-                (
-                    observations = batch_data.observations,
-                    ent_coef = ent_coef,
-                ),
-                train_state,
-            )
+            BenchUtils.bench_sac_ad!($ad_backend, state)
         end setup = begin
-            layer, alg, batch_data, train_state, ent_train_state, target_ps, target_st, rng =
-                BenchUtils.setup_sac_gradient_data()
+            state = BenchUtils.setup_sac_gradient_data()
         end
     end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

PR benchmark CI (`AirspeedVelocity`) always loads the benchmark script with `--bench-on=main`, while still installing the PR package revision. That means API-breaking TrainState changes in a PR are exercised with **main’s** old `benchmark/` script.

https://github.com/KristianHolme/Drill.jl/pull/78 fails with:

```text
MethodError: no method matching compute_gradients(..., ::Drill.PPOTrainState)
```

because main’s setup does `deepcopy(agent.train_state)` and the PR’s `agent.train_state` is now `PPOTrainState`.

## What

Make `benchmark/bench_utils.jl` / `benchmark/benchmarks.jl` dual-API:

- PPO gradient setup unwraps via `Drill.lux_train_state` when present, otherwise uses the Lux `TrainState` directly
- SAC AD benches dispatch on legacy (`aux.ent_train_state` / single TrainState) vs bundle (`SACTrainState`) setups

This is intentionally a **benchmark-only** precursor so `#78` can get a green bench comparison once this lands on `main`.

## Notes

- No package source changes
- After `#78` merges, the dual-path can stay (harmless) or be simplified later
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80934a69-aecc-4128-bf02-20b5050ef4f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80934a69-aecc-4128-bf02-20b5050ef4f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

