### PR TITLE
Speed up PR benchmarks (slim basic suite + `/bench-full`)

### DIFF
--- a/.github/workflows/benchmarks-full.yml
+++ b/.github/workflows/benchmarks-full.yml
@@ -1,0 +1,140 @@
+name: Full benchmarks
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to benchmark"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  bench-full:
+    if: >
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/bench-full') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_PR_URL: ${{ github.event.issue.pull_request.url }}
+          DISPATCH_PR: ${{ github.event.inputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            pr_json=$(gh api "$COMMENT_PR_URL")
+          else
+            pr_json=$(gh api "repos/${REPO}/pulls/${DISPATCH_PR}")
+          fi
+          echo "number=$(jq -r '.number' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "sha=$(jq -r '.head.sha' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+          echo "ref=$(jq -r '.head.ref' <<<"$pr_json")" >> "$GITHUB_OUTPUT"
+
+      - name: React to request
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='rocket' || true
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+          persist-credentials: false
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v3
+        with:
+          version: "1"
+
+      - name: Cache Julia packages
+        uses: julia-actions/cache@v3
+
+      - name: Install and build AirspeedVelocity
+        shell: bash
+        run: |
+          export JULIA_NUM_THREADS=2
+          julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; using Pkg; pkg"add AirspeedVelocity@0.6"'
+          julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+          echo "$HOME/.julia/bin" >> "$GITHUB_PATH"
+
+      - name: Run full benchmarks
+        shell: bash
+        env:
+          JULIA_NUM_THREADS: "2"
+        run: |
+          set -euo pipefail
+          mkdir -p results
+          default_branch="${{ github.event.repository.default_branch }}"
+          benchpkg Drill \
+            --url="${{ github.event.repository.clone_url }}" \
+            --output-dir=results/ \
+            --rev="${default_branch},${{ steps.pr.outputs.sha }}" \
+            --bench-on="${default_branch}" \
+            --script=benchmark/benchmarks.jl \
+            --add=ClassicControlEnvironments,Zygote,Enzyme,Reactant
+
+      - name: Create comment body
+        shell: bash
+        run: |
+          set -euo pipefail
+          default_branch="${{ github.event.repository.default_branch }}"
+          {
+            echo "## Full Benchmark Results (Julia v1)"
+            echo ""
+            echo "Triggered by \`/bench-full\` (or workflow_dispatch). Includes devices and AD backend suites."
+            echo ""
+            echo "<details><summary>Time benchmarks</summary>"
+            echo ""
+            benchpkgtable Drill \
+              --input-dir=results/ \
+              --mode=time \
+              --ratio \
+              --rev="${default_branch},${{ steps.pr.outputs.sha }}"
+            echo ""
+            echo "</details>"
+            echo ""
+            echo "<details><summary>Memory benchmarks</summary>"
+            echo ""
+            benchpkgtable Drill \
+              --input-dir=results/ \
+              --mode=memory \
+              --ratio \
+              --rev="${default_branch},${{ steps.pr.outputs.sha }}"
+            echo ""
+            echo "</details>"
+          } > body.md
+
+      - name: Find existing full-benchmark comment
+        uses: peter-evans/find-comment@v4
+        id: find
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "Full Benchmark Results (Julia v1)"
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-path: body.md
+          edit-mode: replace

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,4 +15,7 @@ jobs:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:
           julia-version: "1"
-          extra-pkgs: "ClassicControlEnvironments,Zygote,Enzyme,Reactant"
+          # Basic suite only (rollouts / training / wrappers). Request a full run with `/bench-full`.
+          filter: "rollouts,training,wrappers"
+          extra-pkgs: "ClassicControlEnvironments"
+          mode: "time,memory"

--- a/README.md
+++ b/README.md
@@ -158,10 +158,31 @@ model = ActorCriticLayer(
 
 ## Benchmarking with [AirSpeedVelocity.jl](https://github.com/MilesCranmer/AirSpeedVelocity.jl)
 
-Benchmarks live in `benchmark/benchmarks.jl` and are used by the CI workflow
-`.github/workflows/benchmarks.yml`.
+Benchmarks live in `benchmark/benchmarks.jl`.
 
-To run locally, first install and build [AirSpeedVelocity.jl](https://github.com/MilesCranmer/AirSpeedVelocity.jl) as described in the readme file,then run:
+### CI
+
+- **Basic suite** (automatic on every PR): `rollouts`, `training`, and `wrappers` via [`.github/workflows/benchmarks.yml`](.github/workflows/benchmarks.yml). Heavy packages (Zygote, Enzyme, Reactant) are not installed for this path.
+- **Full suite** (on demand): comment `/bench-full` on a PR (OWNER/MEMBER/COLLABORATOR), or run the **Full benchmarks** workflow from the Actions tab. This includes `devices` and `ad_backends` and installs Zygote, Enzyme, and Reactant. See [`.github/workflows/benchmarks-full.yml`](.github/workflows/benchmarks-full.yml).
+
+### Local
+
+First install and build [AirSpeedVelocity.jl](https://github.com/MilesCranmer/AirSpeedVelocity.jl) as described in its readme, then:
+
+Basic suite (matches PR CI):
+
+```bash
+mkdir -p benchmark_results
+benchpkg \
+  --path . \
+  --rev dirty,main \
+  --script benchmark/benchmarks.jl \
+  --output-dir benchmark_results \
+  --filter rollouts,training,wrappers \
+  --add ClassicControlEnvironments
+```
+
+Full suite:
 
 ```bash
 mkdir -p benchmark_results

--- a/benchmark/bench_utils.jl
+++ b/benchmark/bench_utils.jl
@@ -8,8 +8,8 @@ using Statistics: mean
 
 const DEFAULT_SEED = 42
 const DEFAULT_N_ENVS = 2
-const DEFAULT_ROLLOUT_STEPS = 64
-const DEFAULT_TRAIN_STEPS = 256
+const DEFAULT_ROLLOUT_STEPS = 32
+const DEFAULT_TRAIN_STEPS = 64
 const DEFAULT_SAMPLES = 1000
 
 function make_cartpole_env(; n_envs::Int = DEFAULT_N_ENVS, seed::Int = DEFAULT_SEED)
@@ -96,7 +96,7 @@ function setup_training_sac(; n_envs::Int = DEFAULT_N_ENVS, max_steps::Int = DEF
 end
 
 # Same workload for device benchmarks (small steps, fixed seed) so CPU vs Reactant are comparable.
-const DEVICE_BENCH_MAX_STEPS = 128
+const DEVICE_BENCH_MAX_STEPS = 64
 
 function setup_training_ppo_device(; n_envs::Int = DEFAULT_N_ENVS, device = nothing)
     env = make_cartpole_env(; n_envs = n_envs)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,16 +2,16 @@ using BenchmarkTools
 using Drill
 using ClassicControlEnvironments
 using Random
-using Zygote
 using Drill.Lux
-using Enzyme: Reverse, set_runtime_activity
-using Reactant
-Reactant.set_default_backend("cpu")
 
 include("bench_utils.jl")
 using .BenchUtils
 
 const SUITE = BenchmarkGroup()
+
+# Prefer a short wall-clock budget so CI stays predictable.
+const BASIC_SECONDS = 1.0
+const BASIC_SAMPLES = 5
 
 rollouts = BenchmarkGroup()
 SUITE["rollouts"] = rollouts
@@ -20,13 +20,13 @@ rollouts["rollout_buffer"] = @benchmarkable begin
     Drill.collect_rollout!(buffer, agent, alg, env)
 end setup = begin
     env, agent, alg, buffer = BenchUtils.setup_rollout_collection()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 rollouts["replay_buffer"] = @benchmarkable begin
     Drill.collect_rollout!(buffer, agent, alg, env, n_steps)
 end setup = begin
     env, agent, alg, buffer, n_steps = BenchUtils.setup_replay_collection()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 training = BenchmarkGroup()
 SUITE["training"] = training
@@ -35,13 +35,13 @@ training["ppo_cartpole"] = @benchmarkable begin
     train!(agent, env, alg, max_steps)
 end setup = begin
     env, agent, alg, max_steps = BenchUtils.setup_training_ppo()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 training["sac_pendulum"] = @benchmarkable begin
     train!(agent, env, alg, max_steps)
 end setup = begin
     env, agent, alg, max_steps = BenchUtils.setup_training_sac()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 # Device benchmarks: compare CPU vs Reactant (when available). Same workload (DEVICE_BENCH_MAX_STEPS).
 # Run with: BenchmarkTools.run(SUITE["devices"]). With Reactant: run Reactant entries; without, only CPU runs.
@@ -52,16 +52,24 @@ devices["ppo_cpu"] = @benchmarkable begin
     train!(agent, env, alg, max_steps)
 end setup = begin
     env, agent, alg, max_steps = BenchUtils.setup_training_ppo_device()
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
+
+const HAS_REACTANT = try
+    @eval using Reactant
+    Reactant.set_default_backend("cpu")
+    true
+catch
+    false
 end
 
-if isdefined(Lux, :reactant_device)
+if HAS_REACTANT && isdefined(Lux, :reactant_device)
     devices["ppo_reactant"] = @benchmarkable begin
         train!(agent, env, alg, max_steps; ad_type = ad_backend)
     end setup = begin
         env, agent, alg, max_steps = BenchUtils.setup_training_ppo_device(; device = Lux.reactant_device())
         ad_backend = AutoEnzyme()
         (env, agent, alg, max_steps, ad_backend)
-    end
+    end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
     # Reactant with CPU backend (no GPU): compare compiled Reactant vs plain CPU.
     devices["ppo_reactant_cpu_backend"] = @benchmarkable begin
         train!(agent, env, alg, max_steps; ad_type = ad_backend)
@@ -72,7 +80,7 @@ if isdefined(Lux, :reactant_device)
         env, agent, alg, max_steps = BenchUtils.setup_training_ppo_device(; device = Lux.reactant_device())
         ad_backend = AutoEnzyme()
         (env, agent, alg, max_steps, ad_backend)
-    end
+    end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 end
 
 wrappers = BenchmarkGroup()
@@ -82,51 +90,65 @@ wrappers["broadcasted_act"] = @benchmarkable begin
     act!(env, actions)
 end setup = begin
     env, monitor_env, normalize_env, actions = BenchUtils.setup_wrapper_envs()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 wrappers["monitor_act"] = @benchmarkable begin
     act!(monitor_env, actions)
 end setup = begin
     env, monitor_env, normalize_env, actions = BenchUtils.setup_wrapper_envs()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 wrappers["normalize_act"] = @benchmarkable begin
     act!(normalize_env, actions)
 end setup = begin
     env, monitor_env, normalize_env, actions = BenchUtils.setup_wrapper_envs()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 wrappers["broadcasted_reset"] = @benchmarkable begin
     reset!(env)
 end setup = begin
     env, monitor_env, normalize_env, actions = BenchUtils.setup_wrapper_envs()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 wrappers["monitor_reset"] = @benchmarkable begin
     reset!(monitor_env)
 end setup = begin
     env, monitor_env, normalize_env, actions = BenchUtils.setup_wrapper_envs()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 wrappers["normalize_reset"] = @benchmarkable begin
     reset!(normalize_env)
 end setup = begin
     env, monitor_env, normalize_env, actions = BenchUtils.setup_wrapper_envs()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 wrappers["multithreaded_act"] = @benchmarkable begin
     act!(threaded_env, actions)
 end setup = begin
     threaded_env, actions = BenchUtils.setup_threaded_envs()
-end
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
 
 wrappers["multithreaded_reset"] = @benchmarkable begin
     reset!(threaded_env)
 end setup = begin
     threaded_env, actions = BenchUtils.setup_threaded_envs()
+end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
+
+const HAS_ZYGOTE = try
+    @eval using Zygote
+    true
+catch
+    false
 end
 
-const ENABLE_AD_BACKEND_BENCHES = true
+const HAS_ENZYME = try
+    @eval using Enzyme: Reverse, set_runtime_activity
+    true
+catch
+    false
+end
+
+const ENABLE_AD_BACKEND_BENCHES = HAS_ZYGOTE && HAS_ENZYME
 if ENABLE_AD_BACKEND_BENCHES
     ad_backends = BenchmarkGroup()
     SUITE["ad_backends"] = ad_backends
@@ -146,7 +168,7 @@ if ENABLE_AD_BACKEND_BENCHES
             Lux.Training.compute_gradients($ad_backend, alg, batch_data, train_state)
         end setup = begin
             alg, batch_data, train_state = BenchUtils.setup_ppo_gradient_data_discrete()
-        end
+        end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
     end
 
     for (name, ad_backend) in ad_backend_types
@@ -154,7 +176,7 @@ if ENABLE_AD_BACKEND_BENCHES
             Lux.Training.compute_gradients($ad_backend, alg, batch_data, train_state)
         end setup = begin
             alg, batch_data, train_state = BenchUtils.setup_ppo_gradient_data_continuous()
-        end
+        end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
     end
 
     for (name, ad_backend) in ad_backend_types[[1, 3]] #dont use enzyme without runtime activity
@@ -163,6 +185,6 @@ if ENABLE_AD_BACKEND_BENCHES
             BenchUtils.bench_sac_ad!($ad_backend, state)
         end setup = begin
             state = BenchUtils.setup_sac_gradient_data()
-        end
+        end seconds = BASIC_SECONDS samples = BASIC_SAMPLES
     end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #80.

## Summary
PR benchmark CI was taking ~35–47 minutes by always running the full suite (including Zygote/Enzyme/Reactant). This splits benchmarks into two tiers:

- **Basic (automatic on PR):** `rollouts`, `training`, `wrappers` only; installs `ClassicControlEnvironments` alone; tighter workloads and 1s/5-sample budgets.
- **Full (on demand):** comment `/bench-full` on a PR (OWNER/MEMBER/COLLABORATOR), or run **Full benchmarks** via `workflow_dispatch`. Includes `devices` and `ad_backends` with Zygote/Enzyme/Reactant.

## Changes
- Make Zygote/Enzyme/Reactant optional in `benchmark/benchmarks.jl` (detailed groups register only when available)
- Reduce `DEFAULT_ROLLOUT_STEPS` / `DEFAULT_TRAIN_STEPS` / `DEVICE_BENCH_MAX_STEPS`
- Slim `.github/workflows/benchmarks.yml` with `--filter` and lighter `extra-pkgs`
- Add `.github/workflows/benchmarks-full.yml` for `/bench-full`
- Document both paths in the README

## Local verification (relative only; not CI-comparable)
- With heavy deps present: suite builds `ad_backends` + Reactant device benches; **12** basic leaves vs **23** full leaves; basic `run` completed (`SMOKE_OK`).
- Without Zygote/Enzyme/Reactant: suite loads with only `devices/ppo_cpu` plus basic groups; `ad_backends` omitted (`OPTIONAL_DEPS_OK`).

## Note
Because the automatic workflow uses `pull_request_target`, GitHub runs the workflow YAML from `main` until this lands. After merge, new PRs get the slim automatic suite; `/bench-full` becomes available once the new workflow is on `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59299ebc-d3a1-487e-bbb8-d8aed12f30b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59299ebc-d3a1-487e-bbb8-d8aed12f30b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

