### PR TITLE
Support TimerOutputs 1.0 with timer verbosity levels 0/1/2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -74,7 +74,7 @@ SciMLBase = "3.36.0"
 Statistics = "1"
 StatsBase = "0.34"
 TensorBoardLogger = "0.1"
-TimerOutputs = "0.5"
+TimerOutputs = "1"
 Wandb = "0.5"
 julia = "1.10"
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ cache = init(
     max_steps,
     # meter: 0=off, 1=progress bar, 2=progress bar + live stats
     # table: PrettyTables dump each update (requires PrettyTables loaded)
-    # timer: print TimerOutputs at the end
-    verbosity = (; meter = 2, table = false, timer = true),
+    # timer: 0=off (zero overhead), 1=record, 2=record + print at end
+    verbosity = (; meter = 2, table = false, timer = 0),
 )
 solve!(cache)
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -16,9 +16,9 @@ model = ActorCriticLayer(observation_space(env), action_space(env))
 # Algorithm with default hyperparameters
 ppo = PPO()
 
-# Train for 100k steps (meter=2: progress bar with live stats; timer printed at end)
+# Train for 100k steps (meter=2: progress bar with live stats; timer off by default)
 prob = RLProblem(env, model)
-cache = init(prob, ppo; max_steps = 100_000, verbosity = (; meter = 2, timer = true))
+cache = init(prob, ppo; max_steps = 100_000, verbosity = (; meter = 2, timer = 2))
 solve!(cache)
 
 # Extract deployment policy
@@ -40,9 +40,9 @@ model = SACLayer(observation_space(env), action_space(env))
 # SAC algorithm
 sac = SAC(learning_rate=3f-4, buffer_capacity=1_000_000)
 
-# Train (meter=1: step progress only; no timer print)
+# Train (meter=1: step progress only; timer disabled)
 prob = RLProblem(env, model)
-sol = solve(prob, sac; max_steps = 500_000, verbosity = (; meter = 1, timer = false))
+sol = solve(prob, sac; max_steps = 500_000, verbosity = (; meter = 1, timer = 0))
 ```
 
 ## Key Hyperparameters

--- a/examples/verbosity.jl
+++ b/examples/verbosity.jl
@@ -50,40 +50,40 @@ end
 
 function main()
     println("Drill verbosity examples (CartPole PPO, $(TOTAL_STEPS) steps)")
-    println("Defaults merge with (; meter = 2, table = false, timer = true)")
+    println("Defaults merge with (; meter = 2, table = false, timer = 0)")
 
-    # Int shorthand: meter only; table/timer forced false
+    # Int shorthand: meter only; table false / timer 0
     run_demo("1) Quiet — Int shorthand verbosity = 0", 0)
 
     run_demo(
         "2) Simple progress bar — meter = 1",
-        (; meter = 1, table = false, timer = false),
+        (; meter = 1, table = false, timer = 0),
     )
 
     run_demo(
         "3) Progress bar + live stats (showvalues) — meter = 2",
-        (; meter = 2, table = false, timer = false),
+        (; meter = 2, table = false, timer = 0),
     )
 
     run_demo(
         "4) PrettyTables dump each update — table = true",
-        (; meter = 0, table = true, timer = false),
+        (; meter = 0, table = true, timer = 0),
     )
 
     run_demo(
-        "5) TimerOutputs at end — timer = true",
-        (; meter = 0, table = false, timer = true),
+        "5) TimerOutputs at end — timer = 2",
+        (; meter = 0, table = false, timer = 2),
     )
 
     run_demo(
-        "6) Combined rich console — meter = 2, table = true, timer = true",
-        (; meter = 2, table = true, timer = true),
+        "6) Combined rich console — meter = 2, table = true, timer = 2",
+        (; meter = 2, table = true, timer = 2),
     )
 
     println()
     println("Done. Partial NamedTuples merge with defaults, e.g.:")
     println("  solve(prob, alg; max_steps, verbosity = (; meter = 1))")
-    println("  # => Verbosity(meter=1, table=false, timer=true)")
+    println("  # => Verbosity(meter=1, table=false, timer=0)")
     return nothing
 end
 

--- a/src/Solve/Solve.jl
+++ b/src/Solve/Solve.jl
@@ -12,7 +12,7 @@ import ProgressMeter
 using ProgressMeter: Progress, next!
 using Random: AbstractRNG, default_rng
 using SciMLBase: ReturnCode
-using TimerOutputs: TimerOutput, print_timer
+using TimerOutputs: TimerOutput, NoTimerOutput, print_timer
 
 import DrillInterface: AbstractParallelEnv, Box, Discrete, act!, action_space, batch,
     number_of_envs, observation_space, observe

--- a/src/Solve/init.jl
+++ b/src/Solve/init.jl
@@ -120,7 +120,7 @@ function init(
         ad_type,
         ReturnCode.Default,
         Dict{Symbol, Any}(),
-        TimerOutput(),
+        selected_verbosity.timer == 0 ? NoTimerOutput() : TimerOutput(),
         nothing,
         Dict{Symbol, Any}(),
     )

--- a/src/Solve/solve.jl
+++ b/src/Solve/solve.jl
@@ -18,7 +18,7 @@ function solve!(cache::RLCache)
         cache.retcode = ReturnCode.Terminated
     end
     finish_training_progress!(cache)
-    if cache.verbosity.timer
+    if cache.verbosity.timer >= 2
         print_timer(cache.timer)
     end
     return RLSolution(cache)

--- a/src/Solve/verbosity.jl
+++ b/src/Solve/verbosity.jl
@@ -6,18 +6,19 @@ Console verbosity controls for training.
 # Fields
 - `meter::Int`: ProgressMeter level — `0` off, `1` step progress, `2` step progress with live stats.
 - `table::Bool`: Print a PrettyTables summary of the latest stats (requires PrettyTables loaded).
-- `timer::Bool`: Print `TimerOutputs` at the end of `solve!`.
+- `timer::Int`: TimerOutputs level — `0` disabled (`NoTimerOutput`, zero-overhead `@timeit`),
+  `1` enabled without printing, `2` enabled and print at the end of `solve!`.
 
 Construct from a `NamedTuple` (merged with defaults), an `Integer` meter shorthand
-(`table`/`timer` false), or a `Verbosity` value via [`normalize_verbosity`](@ref).
+(`table` false / `timer` 0), or a `Verbosity` value via [`normalize_verbosity`](@ref).
 """
 Base.@kwdef struct Verbosity
     meter::Int = 2
     table::Bool = false
-    timer::Bool = true
+    timer::Int = 0
 end
 
-const DEFAULT_VERBOSITY = (; meter = 2, table = false, timer = true)
+const DEFAULT_VERBOSITY = (; meter = 2, table = false, timer = 0)
 
 """
     normalize_verbosity(v) -> Verbosity
@@ -26,10 +27,10 @@ Normalize a verbosity specification to a [`Verbosity`](@ref).
 
 Accepts:
 - a [`Verbosity`](@ref) value
-- a `NamedTuple` merged with defaults `(; meter = 2, table = false, timer = true)`
-- an `Integer` meter shorthand with `table = false` and `timer = false`
+- a `NamedTuple` merged with defaults `(; meter = 2, table = false, timer = 0)`
+- an `Integer` meter shorthand with `table = false` and `timer = 0`
 
-Meter values above `2` warn and clamp to `2`. Negative meters throw.
+Meter and timer values above `2` warn and clamp to `2`. Negative values throw.
 """
 function normalize_verbosity end
 
@@ -43,8 +44,18 @@ function clamp_meter(meter::Integer)
     return m
 end
 
+function clamp_timer(timer::Integer)
+    t = Int(timer)
+    t < 0 && throw(ArgumentError("verbosity.timer must be >= 0, got $t"))
+    if t > 2
+        @warn "verbosity.timer max level is 2; clamping $t to 2"
+        return 2
+    end
+    return t
+end
+
 function normalize_verbosity(v::Verbosity)
-    return Verbosity(clamp_meter(v.meter), v.table, v.timer)
+    return Verbosity(clamp_meter(v.meter), v.table, clamp_timer(v.timer))
 end
 
 function normalize_verbosity(v::NamedTuple)
@@ -52,7 +63,7 @@ function normalize_verbosity(v::NamedTuple)
 end
 
 function normalize_verbosity(meter::Integer)
-    return normalize_verbosity(Verbosity(; meter = Int(meter), table = false, timer = false))
+    return normalize_verbosity(Verbosity(; meter = Int(meter), table = false, timer = 0))
 end
 
 """

--- a/test/test_verbosity.jl
+++ b/test/test_verbosity.jl
@@ -8,30 +8,34 @@ include("setup.jl")
 using .TestSetup
 
 @testset "normalize_verbosity defaults and Int shorthand" begin
-    @test normalize_verbosity((;)) == Verbosity(; meter = 2, table = false, timer = true)
-    @test normalize_verbosity((; meter = 1)) == Verbosity(; meter = 1, table = false, timer = true)
-    @test normalize_verbosity((; table = true, timer = false)) ==
-        Verbosity(; meter = 2, table = true, timer = false)
+    @test normalize_verbosity((;)) == Verbosity(; meter = 2, table = false, timer = 0)
+    @test normalize_verbosity((; meter = 1)) == Verbosity(; meter = 1, table = false, timer = 0)
+    @test normalize_verbosity((; table = true, timer = 1)) ==
+        Verbosity(; meter = 2, table = true, timer = 1)
 
-    @test normalize_verbosity(0) == Verbosity(; meter = 0, table = false, timer = false)
-    @test normalize_verbosity(1) == Verbosity(; meter = 1, table = false, timer = false)
-    @test normalize_verbosity(2) == Verbosity(; meter = 2, table = false, timer = false)
+    @test normalize_verbosity(0) == Verbosity(; meter = 0, table = false, timer = 0)
+    @test normalize_verbosity(1) == Verbosity(; meter = 1, table = false, timer = 0)
+    @test normalize_verbosity(2) == Verbosity(; meter = 2, table = false, timer = 0)
 
-    @test normalize_verbosity(Verbosity(; meter = 1, table = true, timer = false)) ==
-        Verbosity(; meter = 1, table = true, timer = false)
+    @test normalize_verbosity(Verbosity(; meter = 1, table = true, timer = 0)) ==
+        Verbosity(; meter = 1, table = true, timer = 0)
 end
 
-@testset "normalize_verbosity clamps meter > 2 with warning" begin
+@testset "normalize_verbosity clamps meter and timer > 2 with warning" begin
     v = @test_logs (:warn, r"max level is 2") normalize_verbosity(3)
-    @test v == Verbosity(; meter = 2, table = false, timer = false)
+    @test v == Verbosity(; meter = 2, table = false, timer = 0)
 
     v2 = @test_logs (:warn, r"max level is 2") normalize_verbosity((; meter = 5, table = true))
-    @test v2 == Verbosity(; meter = 2, table = true, timer = true)
+    @test v2 == Verbosity(; meter = 2, table = true, timer = 0)
+
+    v3 = @test_logs (:warn, r"timer max level is 2") normalize_verbosity((; timer = 5))
+    @test v3 == Verbosity(; meter = 2, table = false, timer = 2)
 end
 
-@testset "normalize_verbosity rejects negative meter" begin
+@testset "normalize_verbosity rejects negative meter or timer" begin
     @test_throws ArgumentError normalize_verbosity(-1)
     @test_throws ArgumentError normalize_verbosity((; meter = -2))
+    @test_throws ArgumentError normalize_verbosity((; timer = -1))
 end
 
 @testset "print_training_table without extension errors" begin
@@ -52,6 +56,49 @@ end
     end
 end
 
+@testset "timer levels select TimerOutput vs NoTimerOutput" begin
+    n_envs = 1
+    env = BroadcastedParallelEnv([TrackingTargetEnv(8, Random.Xoshiro(2))])
+    layer = ActorCriticModel(observation_space(env), action_space(env); hidden_dims = [16])
+    alg = PPO(; n_steps = 8, batch_size = 8, epochs = 1)
+
+    cache0 = init(
+        RLProblem(env, layer),
+        alg;
+        max_steps = 8,
+        verbosity = (; meter = 0, timer = 0),
+        rng = Random.Xoshiro(1),
+    )
+    @test cache0.verbosity.timer == 0
+    @test nameof(typeof(cache0.timer)) === :NoTimerOutput
+
+    cache1 = init(
+        RLProblem(env, layer),
+        alg;
+        max_steps = 8,
+        verbosity = (; meter = 0, timer = 1),
+        rng = Random.Xoshiro(1),
+    )
+    @test cache1.verbosity.timer == 1
+    @test nameof(typeof(cache1.timer)) === :TimerOutput
+
+    cache2 = init(
+        RLProblem(env, layer),
+        alg;
+        max_steps = 8,
+        verbosity = (; meter = 0, timer = 2),
+        rng = Random.Xoshiro(1),
+    )
+    @test cache2.verbosity.timer == 2
+    @test nameof(typeof(cache2.timer)) === :TimerOutput
+    redirect_stdout(devnull) do
+        redirect_stderr(devnull) do
+            solve!(cache2)
+        end
+    end
+    @test cache2.retcode == ReturnCode.Success
+end
+
 @testset "training smoke with meter=2" begin
     n_envs = 2
     envs = [TrackingTargetEnv(8, Random.Xoshiro(10 + i)) for i in 1:n_envs]
@@ -64,12 +111,13 @@ end
         RLProblem(env, layer),
         alg;
         max_steps,
-        verbosity = (; meter = 2, table = false, timer = false),
+        verbosity = (; meter = 2, table = false, timer = 0),
         rng = Random.Xoshiro(42),
     )
     @test cache.verbosity.meter == 2
     @test cache.verbosity.table == false
-    @test cache.verbosity.timer == false
+    @test cache.verbosity.timer == 0
+    @test nameof(typeof(cache.timer)) === :NoTimerOutput
     @test cache.progress_meter !== nothing
 
     redirect_stderr(devnull) do
@@ -105,7 +153,7 @@ end
         RLProblem(env, layer),
         alg;
         max_steps,
-        verbosity = (; meter = 0, table = true, timer = false),
+        verbosity = (; meter = 0, table = true, timer = 0),
         rng = Random.Xoshiro(7),
     )
     redirect_stdout(devnull) do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump `TimerOutputs` compat from `0.5` to `1` (uses 1.0 `NoTimerOutput` for zero-overhead disabling).
- Change `Verbosity.timer` from `Bool` to `Int` levels:
  - `0` — disabled via `NoTimerOutput` (compile-time zero-overhead `@timeit` when the cache timer type parameter is concrete)
  - `1` — `TimerOutput` recording, no print
  - `2` — recording + `print_timer` at end of `solve!`
- Default `timer` is now `0` (opt-in). Hard break: no `Bool` acceptance.

## Test plan

- [x] Update/normalize verbosity unit tests for Int levels and timer type selection
- [ ] Run `test/test_verbosity.jl`
- [ ] CartPole + Enzyme timing: current baseline vs new `timer=1` vs new `timer=0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-073f5788-9b78-427e-a18b-ab383f91a25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-073f5788-9b78-427e-a18b-ab383f91a25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

